### PR TITLE
add route to example

### DIFF
--- a/docs/introduction/pages/deploying-your-docs/index.mdx
+++ b/docs/introduction/pages/deploying-your-docs/index.mdx
@@ -12,7 +12,7 @@ Now that you have a lot of knowledge about write your docs and you're a real bad
 Like all the other things seen so far, build and deploy your documentation is very easy. The first thing that you need to do is run the build script created at your `package.json`:
 
 ```bash
-$ yarn build
+$ yarn docz:build
 ```
 
 If everything that you did is right, this command will generate all static files for you in `.docz/dist` folder and you see something like that on your terminal:

--- a/docs/introduction/pages/getting-started/index.mdx
+++ b/docs/introduction/pages/getting-started/index.mdx
@@ -50,6 +50,7 @@ So, let's create our first `.mdx` and give it a name:
 ```markdown
 ---
 name: Hello world
+route: /
 ---
 
 # Hello world


### PR DESCRIPTION
> With the server up and your first `.mdx` created, you can open your browser and visit `localhost:3000` and you should see something like this:

It was confusing when this didn't work as expected. If I did't provide `route: /` in the document settings, the first thing I see when I visit `localhost:3000` is an error page.